### PR TITLE
fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+/prompts.json

--- a/scripts/multi_prompt_manager.py
+++ b/scripts/multi_prompt_manager.py
@@ -28,7 +28,7 @@ class MultiPromptManager(scripts.Script):
     def ui(self, is_img2img):
         # Load existing prompts
         if os.path.exists(PROMPTS_FILE):
-            with open(PROMPTS_FILE, 'r') as f:
+            with open(PROMPTS_FILE, 'r', encoding='utf-8') as f:
                 prompts = json.load(f)
         else:
             prompts = {}
@@ -46,7 +46,7 @@ class MultiPromptManager(scripts.Script):
                 new_name = f"prompt {i}"
 
             prompts[new_name] = {'prompt': new_prompt, 'is_negative': is_negative}
-            with open(PROMPTS_FILE, 'w') as f:
+            with open(PROMPTS_FILE, 'w', encoding='utf-8') as f:
                 json.dump(prompts, f)
             return gr.Dropdown.update(choices=list(prompts.keys())), ""
 

--- a/scripts/multi_prompt_manager.py
+++ b/scripts/multi_prompt_manager.py
@@ -48,14 +48,14 @@ class MultiPromptManager(scripts.Script):
 
             prompts[new_name] = {'prompt': new_prompt, 'is_negative': is_negative}
             with open(PROMPTS_FILE, 'w', encoding='utf-8') as f:
-                json.dump(prompts, f)
+                json.dump(prompts, f, indent=4, ensure_ascii=False)
             return gr.Dropdown.update(choices=list(prompts.keys())), ""
 
         def delete_prompt(selected_prompt):
             if selected_prompt in prompts:
                 del prompts[selected_prompt]
                 with open(PROMPTS_FILE, 'w') as f:
-                    json.dump(prompts, f)
+                    json.dump(prompts, f, indent=4, ensure_ascii=False)
                 return gr.Dropdown.update(choices=list(prompts.keys())), "", ""
             return gr.Dropdown.update(), "", ""
 

--- a/scripts/multi_prompt_manager.py
+++ b/scripts/multi_prompt_manager.py
@@ -6,7 +6,8 @@ import os
 
 # Shoutout to https://github.com/EnsignMK/ExampleSendText for giving an example of how to send input to the main prompt :)
 
-PROMPTS_FILE = "prompts.json"
+EXTENSION_ROOT = scripts.basedir()
+PROMPTS_FILE = os.path.join(EXTENSION_ROOT, "prompts.json")
 
 
 def copy_from_active_prompt(is_negative, pos_prompt, neg_prompt):

--- a/scripts/multi_prompt_manager.py
+++ b/scripts/multi_prompt_manager.py
@@ -91,6 +91,8 @@ class MultiPromptManager(scripts.Script):
                         use_prompt_button.click(fn=use_prompt, inputs=[prompt_input, negative_prompt_toggle], outputs=[self.boxx, self.neg_boxx])
                         copy_prompt_button.click(fn=copy_from_active_prompt, inputs=[negative_prompt_toggle, self.boxx, self.neg_boxx], outputs=[prompt_input])
 
+        [setattr(c, 'do_not_save_to_config', True) for c in (prompt_dropdown, new_prompt_name, prompt_input)]
+
         return [prompt_dropdown, use_prompt_button, save_button, delete_button, copy_prompt_button, new_prompt_name, prompt_input, negative_prompt_toggle]
     
     def after_component(self, component, **kwargs):

--- a/scripts/multi_prompt_manager.py
+++ b/scripts/multi_prompt_manager.py
@@ -8,10 +8,12 @@ import os
 
 PROMPTS_FILE = "prompts.json"
 
+
 def copy_from_active_prompt(is_negative, pos_prompt, neg_prompt):
     if is_negative:
         return neg_prompt
     return pos_prompt
+
 
 class MultiPromptManager(scripts.Script):
     def __init__(self) -> None:
@@ -99,5 +101,6 @@ class MultiPromptManager(scripts.Script):
             self.neg_boxx = component
         if kwargs.get("elem_id") == "img2img_neg_prompt":
             self.neg_boxxIMG = component
+
 
 print("Successfully loaded Multi-Prompt Manager extension.")


### PR DESCRIPTION
Fixes

[explicitly specify utf-8 encoding](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/commit/13dc29604b8a4a10e9431d9c58f68f94b4876695)
if you don't it's basically an error waiting to happen especially for non english users

[move prompts.json to extension root](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/commit/e59bb22b9fb81730e0fe842e98efaea3888a0007)
[.gitignore prompts.json](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/commit/5bc7c6c1bf7e8ad8dbf9b90c6971a64110c954f2)
don't put stuff in webui root especially,
don't put stuff in current work directory,
if you must put stiff in shared space don't use a generic name like prompts.json

---

improvements

[imporve prompts.json readability](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/commit/8b518dea16797b7efa6e664020aa1ccaa034d79b)
json.dump(prompts, f, indent=4, ensure_ascii=False)

[PEP 8: E305](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/commit/78854605f075a8f8032ce1ec90f35c1d1e768c1f)

[attr do_not_save_to_config for input components](https://github.com/camdenFletcher03/sd-webui-Multi-Prompt-Manager/pull/1/commits/4a237e77b76b4563cad4bc33fd9d0df10076b654)
prevent input beening saving to `ui-config.json`
> fror more see WebUI Settings > Defaults > 
